### PR TITLE
Dhis2 5181 remove avatar from user

### DIFF
--- a/src/layout/AvatarEditor.component.js
+++ b/src/layout/AvatarEditor.component.js
@@ -23,7 +23,11 @@ class AvatarEditor extends Component {
                 : null,
             loading: false,
         };
+        this.inputRef = null;
     }
+
+    getInputRef = () => this.inputRef;
+    setInputRef = node => this.inputRef = node;
 
     parseAvatarSrc(avatarId) {
         return `${this.api.baseUrl}/fileResources/${avatarId}/data`;
@@ -68,6 +72,9 @@ class AvatarEditor extends Component {
 
     onRemoveIcon = () => {
         this.props.onChange({ target: { value: null } });
+        // Clear input here to ensure that a re-upload of a previously used file is not ignored
+        const input = this.getInputRef();
+        input.value = null;
         this.setState({ avatarSrc: null });
     };
 
@@ -124,13 +131,16 @@ class AvatarEditor extends Component {
                             style={{ display: 'none' }}
                             type="file"
                             accept="image/*"
+                            ref={this.setInputRef}
                         />
                     </FlatButton>
-                    <FlatButton
-                        icon={<ActionDelete />}
-                        label={d2.i18n.getTranslation('remove_avatar')}
-                        onClick={this.onRemoveIcon}
-                    />
+                    {avatarSrc && (
+                        <FlatButton
+                            icon={<ActionDelete />}
+                            label={d2.i18n.getTranslation('remove_avatar')}
+                            onClick={this.onRemoveIcon}
+                        />
+                    )}
                 </div>
             </div>
         );

--- a/src/profile/profile.actions.js
+++ b/src/profile/profile.actions.js
@@ -38,7 +38,7 @@ userProfileActions.save.subscribe(({ data, complete, error }) => {
             }
         }
 
-        getPromise(key, value, payload, userProfileStore.state.id, d2)
+        getProfileUpdatePromise(key, value, payload, userProfileStore.state.id, d2)
             .then(() => {
                 log.debug('User Profile updated successfully.');
                 userSettingsActions.showSnackbarMessage({
@@ -58,7 +58,7 @@ userProfileActions.save.subscribe(({ data, complete, error }) => {
     });
 });
 
-function getPromise(key, value, payload, userId, d2) {
+function getProfileUpdatePromise(key, value, payload, userId, d2) {
     const api = d2.Api.getApi();
     if (key === 'avatar') {
         if (value) {

--- a/src/profile/profile.actions.js
+++ b/src/profile/profile.actions.js
@@ -38,12 +38,7 @@ userProfileActions.save.subscribe(({ data, complete, error }) => {
             }
         }
 
-        // Post avatar directly to the `/user/<ID>` endpoint, because d2 update calls to `/me` cause issues
-        const api = d2.Api.getApi();
-        const d2Method = key === 'avatar' ? 'patch' : 'update';
-        const url = key === 'avatar' ? `/users/${userProfileStore.state.id}` : 'me';
-
-        api[d2Method](url, payload)
+        getPromise(key, value, payload, userProfileStore.state.id, d2)
             .then(() => {
                 log.debug('User Profile updated successfully.');
                 userSettingsActions.showSnackbarMessage({
@@ -62,5 +57,28 @@ userProfileActions.save.subscribe(({ data, complete, error }) => {
             });
     });
 });
+
+function getPromise(key, value, payload, userId, d2) {
+    const api = d2.Api.getApi();
+    if (key === 'avatar') {
+        if (value) {
+            // Set avatar
+            // Post avatar directly to the `/user/<ID>` endpoint, because d2 update calls to `/me` cause issues
+            return api.patch(`/users/${userId}`, payload);
+        } else {
+            // Clear avatar
+            return removeAvatar(userId, api);
+        }
+    }
+
+    return api.update('me', payload)
+}
+
+async function removeAvatar(userId, api) {
+    const url = `/users/${userId}`;
+    const user = await api.get(url, {fields: ':owner'});
+    delete user.avatar;
+    return api.update(url, user);
+}
 
 export default userProfileActions;


### PR DESCRIPTION
# Removing an avatar via the webapi
- The only way to (currently) remove an avatar is by sending a PUT request to the `/users/<ID>` endpoint with the full user model, without the `avatar` property
- This means we now have three different promises for updating a user profile:
    1. Most fields: do a PUT to `/me` with `{ key: value }` payload
    2. Setting an avatar: do a PATCH to `/users/<ID>` with `{ key: value }` payload
    3. Clearing an avatar: do a PUT to `/users/<ID>`  with full user-object payload minus `avatar`
- So I extracted the logic to use the correct promise into a function
- To obtain the correct full user payload object structure, I opted for just doing a GET call to the `/users/<ID>` endpoint. The alternative would have been to manually construct the correct payload object structure from the `userProfileStore.state`, but this would be very prone to errors. Especially because a PUT request strips properties that have been omitted.

# AvatarEditor.component improvements
- I am now hiding the delete button if no avatar is present
- There was a small bug that would occur when selecting fileA, removing, then selecting fileA again. At this point the input's value would still be fileA, and selecting fileA again would not trigger the onChange (this is native browser behaviour). To avoid this I am now clearing the input's value insede the `onRemove` function