### PR TITLE
DHIS2-5313 fresh profile picture not found after navigating to other section

### DIFF
--- a/src/aboutPage/AboutPage.component.js
+++ b/src/aboutPage/AboutPage.component.js
@@ -92,7 +92,7 @@ class AboutPage extends Component {
                     this.context.d2,
                     this.translate
                 );
-                if (value) {
+                if (value || value === false) {
                     acc.push({
                         label: this.translate(attribute.label),
                         value

--- a/src/aboutPage/AboutPage.component.js
+++ b/src/aboutPage/AboutPage.component.js
@@ -22,7 +22,11 @@ const attributes = {
         {
             label: 'web_api',
             getDisplayValue: (_value, d2, translate) => (
-                <a target="_blank" href={`${d2.system.systemInfo.contextPath}/api`}>
+                <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={`${d2.system.systemInfo.contextPath}/api`}
+                >
                     {translate('browse_it_here')}
                 </a>
             ),

--- a/src/aboutPage/AboutSection.component.js
+++ b/src/aboutPage/AboutSection.component.js
@@ -19,15 +19,17 @@ const AboutSection = ({ header, attributes }) => (
         <Card style={styles.card}>
             <CardText>
                 <div className="info-content">
-                    {attributes
-                        .map(({ label, value }) => (
-                            <InfoItem
-                                key={label}
-                                label={label}
-                                value={value}
-                            />
-                        ))
-                    }
+                    {attributes.map(({ label, value }) => (
+                        <InfoItem
+                            key={label}
+                            label={label}
+                            value={
+                                typeof value === 'boolean'
+                                    ? value.toString()
+                                    : value
+                            }
+                        />
+                    ))}
                 </div>
             </CardText>
         </Card>
@@ -39,8 +41,8 @@ AboutSection.propTypes = {
     attributes: PropTypes.arrayOf(
         PropTypes.shape({
             label: PropTypes.string.isRequired,
-            value: PropTypes.node,
-        }),
+            value: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+        })
     ).isRequired,
 };
 

--- a/src/layout/AvatarEditor.component.js
+++ b/src/layout/AvatarEditor.component.js
@@ -53,7 +53,7 @@ class AvatarEditor extends Component {
         try {
             const postResponse = await this.api.post('fileResources', formData);
             const imageId = postResponse.response.fileResource.id;
-            onChange({ target: { value: imageId } });
+            onChange({ target: { value: { id: imageId } } });
             this.setState({
                 loading: false,
                 avatarSrc: this.parseAvatarSrc(imageId),

--- a/src/profile/profile.actions.js
+++ b/src/profile/profile.actions.js
@@ -64,7 +64,7 @@ function getProfileUpdatePromise(key, value, payload, userId, d2) {
         if (value) {
             // Set avatar
             // Post avatar directly to the `/user/<ID>` endpoint, because d2 update calls to `/me` cause issues
-            return api.patch(`/users/${userId}`, payload);
+            return api.patch(`/users/${userId}`, { avatar: value.id });
         } else {
             // Clear avatar
             return removeAvatar(userId, api);


### PR DESCRIPTION
The problem I fixed was that the structure of the avatar state was inconsistent:
1) In the webapi payload it looks like this, and gets used in the state:
```javascript
{
    avatar: {
        id: '<AVATAR_ID>',
    },
}
```
2) But after uploading, in `onChange`, I was just sending the id, so the state would look like this:
```javascript
{
    avatar: '<AVATAR_ID>',
}
```

After updating the structure of the parameter for onChange, I also had to tweak the payload for the PATCH call.

And finally I included some unrelated minor fixes that were causing warnings:
- About page can now render booleans too
- Link that gets opened in new tab/window gets rel="noopener noreferrer" which was recommended by the linter