### PR TITLE
fix(account): introduce local password validation identical to dhis2core

### DIFF
--- a/src/account/AccountEditor.component.js
+++ b/src/account/AccountEditor.component.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { isValidPassword } from 'd2-ui/lib/forms/Validators';
-
 import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
 import TextField from 'd2-ui/lib/form-fields/TextField';
 import { FlatButton, RaisedButton } from 'material-ui';
 
 import appActions from '../app.actions';
 import accountActions from './account.actions';
+import isValidPassword from './isValidPassword';
 
 
 class AccountEditor extends Component {

--- a/src/account/isValidPassword.js
+++ b/src/account/isValidPassword.js
@@ -1,0 +1,18 @@
+// Atleast one digit
+const oneDigit = /^(?=.*\d)/;
+
+// Atleast one uppercase character
+const oneUpperCase = /^(?=.*[A-Z])/;
+
+// Atleast one special character
+// Using this regex to match all non-alphanumeric characters to match server-side implementation
+// https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/SpecialCharacterValidationRule.java#L39
+const oneSpecialCharacter = /[^a-zA-Z0-9]/;
+
+export default function isValidPassword(value) {
+    if (!value) {
+        return true;
+    }
+    return oneDigit.test(value) && oneUpperCase.test(value) && oneSpecialCharacter.test(value) && value.length > 7 && value.length < 36;
+}
+isValidPassword.message = 'invalid_password';


### PR DESCRIPTION
As discussed on Slack, fixing this in d2-ui was not feasible, so I've introduced a local function here.

Please also see https://github.com/dhis2/user-app/pull/55 which aligns the "special-character" regex for password validation in the user-app