### PR TITLE
fix(account-editor): switch to new password update endpoint (DHIS2-7669)

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -132,6 +132,7 @@ log_out=Log out
 
 invalid_password=Password should be at least 8 characters with at least 1 digit, 1 uppercase letter and 1 special character"
 passwords_do_not_match=The entered values do not match. Please re-enter.
+old_password_empty=Please provide your old password
 use_system_default=Use system default
 true_notifications=Yes
 false_notifications=No

--- a/src/account/AccountEditor.component.js
+++ b/src/account/AccountEditor.component.js
@@ -66,7 +66,7 @@ class AccountEditor extends Component {
         } else if (!this.isNotEmpty(this.state.newPassword) || !this.isNotEmpty(this.state.reNewPassword)) {
             appActions.showSnackbarMessage({ message: this.context.d2.i18n.getTranslation('password_do_not_match'), status:'error'});
         } else {
-            accountActions.setPassword(this.state.newPassword, this.clearRepeatPassword);
+            accountActions.setPassword(this.state.oldPassword, this.state.newPassword, this.clearRepeatPassword);
         }
     }
 

--- a/src/account/AccountEditor.component.js
+++ b/src/account/AccountEditor.component.js
@@ -19,7 +19,6 @@ class AccountEditor extends Component {
             reNewPassword: '',
             wrongOldPasswordText: '',
         };
-        this.isVerifiedPassword.message = "wrong_old_password";
     }
 
     isSamePassword = (value) => {
@@ -28,20 +27,6 @@ class AccountEditor extends Component {
 
     isNotEmpty = (value) => {
         return value && String(value).trim().length > 0;
-    }
-
-    isVerifiedPassword = (value) => {
-        const api = this.context.d2.Api.getApi();
-        return new Promise((resolve, reject) => {
-            api.post('/me/verifyPassword', { password: value })
-                .then((res) => {
-                    if (res.isCorrectPassword === true) {
-                        resolve();
-                    } else {
-                        reject(this.context.d2.i18n.getTranslation('please_enter_the_correct_password'));
-                    }
-                });
-        });
     }
 
     clearRepeatPassword = () => {
@@ -64,7 +49,9 @@ class AccountEditor extends Component {
         } else if (formState.valid !== true) {
             appActions.showSnackbarMessage({ message: this.context.d2.i18n.getTranslation('fix_errors_and_try_again'), status:'error' });
         } else if (!this.isNotEmpty(this.state.newPassword) || !this.isNotEmpty(this.state.reNewPassword)) {
-            appActions.showSnackbarMessage({ message: this.context.d2.i18n.getTranslation('password_do_not_match'), status:'error'});
+            appActions.showSnackbarMessage({ message: this.context.d2.i18n.getTranslation('passwords_do_not_match'), status:'error'});
+        } else if (!this.isNotEmpty(this.state.oldPassword)) {
+            appActions.showSnackbarMessage({ message: this.context.d2.i18n.getTranslation('old_password_empty'), status:'error'});
         } else {
             accountActions.setPassword(this.state.oldPassword, this.state.newPassword, this.clearRepeatPassword);
         }
@@ -102,9 +89,8 @@ class AccountEditor extends Component {
                 },
                 validators: [{
                     validator: this.isNotEmpty,
-                    message: '',
+                    message: this.context.d2.i18n.getTranslation('value_required'),
                 }],
-                asyncValidators: [this.isVerifiedPassword],
             },
             {
                 name: 'newPassword',

--- a/src/account/account.actions.js
+++ b/src/account/account.actions.js
@@ -12,11 +12,12 @@ const accountActions = Action.createActionsFromNames([
     'getQrCode',
 ]);
 
-accountActions.setPassword.subscribe(({ data: [password, onSuccess], complete, error }) => {
-    const payload = { userCredentials: { password } };
+accountActions.setPassword.subscribe(({ data: [oldPassword, newPassword, onSuccess], complete, error }) => {
+    const payload = { oldPassword, newPassword };
+
     getD2().then((d2) => {
         const api = d2.Api.getApi();
-        api.update('/me', payload)
+        api.update('/me/changePassword', payload)
             .then(() => {
                 log.debug('Password updated successfully.');
                 appActions.showSnackbarMessage({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,6 @@ try {
 console.log(JSON.stringify(dhisConfig, null, 2), '\n');
 
 function log(req, res, opt) {
-    req.headers.Authorization = dhisConfig.authorization;
     console.log('[PROXY]'.cyan.bold, req.method.green.bold, req.url.magenta, '=>'.dim, opt.target.dim);
 }
 


### PR DESCRIPTION
This PR has three commits under it. What I've done in https://github.com/dhis2/user-profile-app/commit/f058909b5d8ecf6ba715e896d24158255d2421db is up for discussion....

Prior to using the new endpoint, this form was asynchronously validating the current password, and then as a second step the new password was submitted. However, with this new endpoint, I thought it would be better (and quite likely a little bit more secure) to remove this async validation part of the old password, since that is being validated in the PUT call to `/me/changePassword` anyway.
@zubaira @varl would you please let me know if you agree with my reasoning above?

If not, I should revert the last commit before we merge this in.