### PR TITLE
fix: prevent old password autofill

### DIFF
--- a/src/account/AccountEditor.component.js
+++ b/src/account/AccountEditor.component.js
@@ -102,6 +102,7 @@ class AccountEditor extends Component {
                     floatingLabelText: this.context.d2.i18n.getTranslation('new_password'),
                     style: { width: '100%' },
                     changeEvent: 'onBlur',
+                    autoComplete: 'new-password',
                 },
                 validators: [{
                     validator: isValidPassword,
@@ -117,6 +118,7 @@ class AccountEditor extends Component {
                     floatingLabelText: this.context.d2.i18n.getTranslation('repeat_new_password'),
                     style: { width: '100%' },
                     changeEvent: 'onBlur',
+                    autoComplete: 'new-password',
                 },
                 validators: [{
                     validator: this.isSamePassword,

--- a/src/account/AccountEditor.component.js
+++ b/src/account/AccountEditor.component.js
@@ -86,6 +86,7 @@ class AccountEditor extends Component {
                     floatingLabelText: this.context.d2.i18n.getTranslation('old_password'),
                     style: { width: '100%' },
                     changeEvent: 'onBlur',
+                    autoComplete: 'new-password',
                 },
                 validators: [{
                     validator: this.isNotEmpty,

--- a/src/layout/FormFields.component.js
+++ b/src/layout/FormFields.component.js
@@ -301,7 +301,9 @@ class FormFields extends Component {
         return (
             <div className="content-area">
                 <div style={styles.header}>{this.props.pageLabel}</div>
-                {this.renderFields(this.props.fieldKeys)}
+                <form autoComplete="off">
+                    {this.renderFields(this.props.fieldKeys)}
+                </form>
             </div>
         );
     }


### PR DESCRIPTION
This puts `autocomplete="off"` on the form element and `autocomplete="new-password"` on the password inputs. By adding both of these attributes we prevent browsers from autofilling.

Note:
I initially only added the `autocomplete="new-password"` property on the `oldPassword` field, but I am afraid that some browser might then start regarding the next sibling password input as the one they should be autofilling. In my second commit I added `autocomplete="new-password"` to the other fields too. It might not be required strictly speaking, but it's definitely not wrong to have them there too.