### PR TITLE
fix(account): login again after password change

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -149,3 +149,6 @@ false=No
 yes=Yes
 no=No
 
+password_changed_successfully=Password changed successfully
+login_again=You need to login again to continue using the application.
+login=Login

--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -152,4 +152,3 @@ no=No
 password_changed_successfully=Password changed successfully
 login_again=You need to login again to continue using the application.
 login=Login
-password=Password

--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -152,3 +152,4 @@ no=No
 password_changed_successfully=Password changed successfully
 login_again=You need to login again to continue using the application.
 login=Login
+password=Password

--- a/src/account/PasswordChangeSuccessDialog.js
+++ b/src/account/PasswordChangeSuccessDialog.js
@@ -1,93 +1,35 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FlatButton, Dialog } from 'material-ui';
-import TextField from 'd2-ui/lib/form-fields/TextField';
-import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
 
-import accountActions from './account.actions';
-import isValidPassword from './isValidPassword';
+import appActions from '../app.actions';
 
-class PasswordChangeSuccessDialog extends Component {
-    state = {
-        password: ''
-    }
-    formBuilder = null
+// In development environments this won't provide the correct behavior
+// because the app is hosted on a different port, but once an app is deployed
+// reloading the window with an invalidated session will redirect to the login page
+const reload = () => {
+    appActions.setCategory('account')
+    window.location.reload(true);
+}
 
-    setPassword = (_, password) => {
-        this.setState({ password })
-    }
+function PasswordChangeSuccessDialog(props, context) {
+    const titleText = context.d2.i18n.getTranslation('password_changed_successfully');
+    const bodyText = context.d2.i18n.getTranslation('login_again');
+    const buttonText = context.d2.i18n.getTranslation('login');
 
-    setRef = node => {
-        this.formBuilder = node;
-    }
-
-    login = () => {
-        accountActions.login({
-            username: this.context.d2.currentUser.username,
-            password: this.state.password
-        })
-    }
-    
-    render() {
-        const titleText = this.context.d2.i18n.getTranslation('password_changed_successfully');
-        const bodyText = this.context.d2.i18n.getTranslation('login_again');
-        const buttonText = this.context.d2.i18n.getTranslation('login');
-
-        const fields = [
-            {
-                name: 'username',
-                component: TextField,
-                value: this.context.d2.currentUser.username,
-                props: {
-                    floatingLabelText: this.context.d2.i18n.getTranslation('username'),
-                    style: { width: '100%' },
-                    disabled: true,
-                },
-            },
-            {
-                name: 'password',
-                component: TextField,
-                value: this.state.password,
-                props: {
-                    type: 'password',
-                    floatingLabelText: this.context.d2.i18n.getTranslation('password'),
-                    style: { width: '100%' },
-                    changeEvent: 'onBlur',
-                    autoComplete: 'new-password',
-                },
-                validators: [{
-                    validator: isValidPassword,
-                    message: this.context.d2.i18n.getTranslation(isValidPassword.message),
-                }],
-            },
-        ]
-
-        const isValid = !!(this.formBuilder && this.formBuilder.state.form.valid && this.state.password);
-
-        const buttons = [
-            <FlatButton
-                label={buttonText} 
-                primary onClick={this.login} 
-                disabled={!isValid}
-            />,
-        ];
-
-        return (
-            <Dialog
-                title={titleText}
-                actions={buttons}
-                modal
-                open
-            >
-                <p>{bodyText}</p>
-                <FormBuilder 
-                    fields={fields} 
-                    onUpdateField={this.setPassword} 
-                    ref={this.setRef} 
-                />
-            </Dialog>
-        );
-    }
+    const buttons = [
+        <FlatButton label={buttonText} primary onClick={reload} />,
+    ];
+    return (
+        <Dialog
+            title={titleText}
+            actions={buttons}
+            modal
+            open
+        >
+            {bodyText}
+        </Dialog>
+    );
 }
 
 PasswordChangeSuccessDialog.contextTypes = { 

--- a/src/account/PasswordChangeSuccessDialog.js
+++ b/src/account/PasswordChangeSuccessDialog.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FlatButton, Dialog } from 'material-ui';
+
+import appActions from '../app.actions';
+
+// In development environments this won't provide the correct behavior
+// because the app is hosted on a different port, but once an app is deployed
+// reloading the window with an invalidated session will redirect to the login page
+const reload = () => {
+    appActions.setCategory('account')
+    window.location.reload(true);
+}
+
+function PasswordChangeSuccessDialog(props, context) {
+    const titleText = context.d2.i18n.getTranslation('password_changed_successfully');
+    const bodyText = context.d2.i18n.getTranslation('login_again');
+    const buttonText = context.d2.i18n.getTranslation('login');
+
+    const buttons = [
+        <FlatButton label={buttonText} primary onClick={reload} />,
+    ];
+    return (
+        <Dialog
+            title={titleText}
+            actions={buttons}
+            modal
+            open
+        >
+            {bodyText}
+        </Dialog>
+    );
+}
+
+PasswordChangeSuccessDialog.contextTypes = { 
+    d2: PropTypes.object.isRequired
+};
+
+export default PasswordChangeSuccessDialog;

--- a/src/account/PasswordChangeSuccessDialog.js
+++ b/src/account/PasswordChangeSuccessDialog.js
@@ -1,35 +1,93 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FlatButton, Dialog } from 'material-ui';
+import TextField from 'd2-ui/lib/form-fields/TextField';
+import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
 
-import appActions from '../app.actions';
+import accountActions from './account.actions';
+import isValidPassword from './isValidPassword';
 
-// In development environments this won't provide the correct behavior
-// because the app is hosted on a different port, but once an app is deployed
-// reloading the window with an invalidated session will redirect to the login page
-const reload = () => {
-    appActions.setCategory('account')
-    window.location.reload(true);
-}
+class PasswordChangeSuccessDialog extends Component {
+    state = {
+        password: ''
+    }
+    formBuilder = null
 
-function PasswordChangeSuccessDialog(props, context) {
-    const titleText = context.d2.i18n.getTranslation('password_changed_successfully');
-    const bodyText = context.d2.i18n.getTranslation('login_again');
-    const buttonText = context.d2.i18n.getTranslation('login');
+    setPassword = (_, password) => {
+        this.setState({ password })
+    }
 
-    const buttons = [
-        <FlatButton label={buttonText} primary onClick={reload} />,
-    ];
-    return (
-        <Dialog
-            title={titleText}
-            actions={buttons}
-            modal
-            open
-        >
-            {bodyText}
-        </Dialog>
-    );
+    setRef = node => {
+        this.formBuilder = node;
+    }
+
+    login = () => {
+        accountActions.login({
+            username: this.context.d2.currentUser.username,
+            password: this.state.password
+        })
+    }
+    
+    render() {
+        const titleText = this.context.d2.i18n.getTranslation('password_changed_successfully');
+        const bodyText = this.context.d2.i18n.getTranslation('login_again');
+        const buttonText = this.context.d2.i18n.getTranslation('login');
+
+        const fields = [
+            {
+                name: 'username',
+                component: TextField,
+                value: this.context.d2.currentUser.username,
+                props: {
+                    floatingLabelText: this.context.d2.i18n.getTranslation('username'),
+                    style: { width: '100%' },
+                    disabled: true,
+                },
+            },
+            {
+                name: 'password',
+                component: TextField,
+                value: this.state.password,
+                props: {
+                    type: 'password',
+                    floatingLabelText: this.context.d2.i18n.getTranslation('password'),
+                    style: { width: '100%' },
+                    changeEvent: 'onBlur',
+                    autoComplete: 'new-password',
+                },
+                validators: [{
+                    validator: isValidPassword,
+                    message: this.context.d2.i18n.getTranslation(isValidPassword.message),
+                }],
+            },
+        ]
+
+        const isValid = !!(this.formBuilder && this.formBuilder.state.form.valid && this.state.password);
+
+        const buttons = [
+            <FlatButton
+                label={buttonText} 
+                primary onClick={this.login} 
+                disabled={!isValid}
+            />,
+        ];
+
+        return (
+            <Dialog
+                title={titleText}
+                actions={buttons}
+                modal
+                open
+            >
+                <p>{bodyText}</p>
+                <FormBuilder 
+                    fields={fields} 
+                    onUpdateField={this.setPassword} 
+                    ref={this.setRef} 
+                />
+            </Dialog>
+        );
+    }
 }
 
 PasswordChangeSuccessDialog.contextTypes = { 

--- a/src/account/account.actions.js
+++ b/src/account/account.actions.js
@@ -10,7 +10,6 @@ const accountActions = Action.createActionsFromNames([
     'setPassword',
     'setTwoFactorStatus',
     'getQrCode',
-    'login'
 ]);
 
 accountActions.setPassword.subscribe(({ data: [oldPassword, newPassword, onSuccess], complete, error }) => {
@@ -73,34 +72,6 @@ accountActions.setTwoFactorStatus.subscribe(({ data: twoFA, complete, error }) =
 });
 
 accountActions.getQrCode.subscribe(() => {
-});
-
-accountActions.login.subscribe(async ({ data: { username, password } }) => {
-    appActions.setCategory('account');
-
-    try {
-        const d2 = await getD2();
-        const server = d2.system.systemInfo.contextPath;
-
-        await fetch(
-                `${server}/dhis-web-commons-security/login.action`,
-                {
-                    method: 'POST',
-                    credentials: 'include',
-                    body: `j_username=${username}&j_password=${password}`,
-                    headers: {
-                        'X-Requested-With': 'XMLHttpRequest',
-                        Accept: 'application/json',
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                    },
-                }
-            )
-    } catch (e) {
-        // This will always happen because we don't have a real login endpoint
-    } finally {
-        window.location.reload()
-    }
-
 });
 
 export default accountActions;

--- a/src/account/account.actions.js
+++ b/src/account/account.actions.js
@@ -20,10 +20,9 @@ accountActions.setPassword.subscribe(({ data: [oldPassword, newPassword, onSucce
         api.update('/me/changePassword', payload)
             .then(() => {
                 log.debug('Password updated successfully.');
-                appActions.showSnackbarMessage({
-                    message: d2.i18n.getTranslation('password_update_success'),
-                    status: 'success',
-                });
+                
+                appActions.setCategory('passwordChanged');
+
                 onSuccess();
                 complete();
             })

--- a/src/account/account.actions.js
+++ b/src/account/account.actions.js
@@ -28,9 +28,14 @@ accountActions.setPassword.subscribe(({ data: [oldPassword, newPassword, onSucce
                 complete();
             })
             .catch((err) => {
+                const message = err && err.message && typeof err.message === 'string' 
+                    ? err.message 
+                    : d2.i18n.getTranslation('password_update_failed');
+
                 appActions.showSnackbarMessage({
-                    message: d2.i18n.getTranslation('password_update_failed'),
+                    message,
                     status: 'error',
+                    permanent: true,
                 });
                 log.error('Failed to update password:', err);
                 error();

--- a/src/account/account.actions.js
+++ b/src/account/account.actions.js
@@ -10,6 +10,7 @@ const accountActions = Action.createActionsFromNames([
     'setPassword',
     'setTwoFactorStatus',
     'getQrCode',
+    'login'
 ]);
 
 accountActions.setPassword.subscribe(({ data: [oldPassword, newPassword, onSuccess], complete, error }) => {
@@ -72,6 +73,34 @@ accountActions.setTwoFactorStatus.subscribe(({ data: twoFA, complete, error }) =
 });
 
 accountActions.getQrCode.subscribe(() => {
+});
+
+accountActions.login.subscribe(async ({ data: { username, password } }) => {
+    appActions.setCategory('account');
+
+    try {
+        const d2 = await getD2();
+        const server = d2.system.systemInfo.contextPath;
+
+        await fetch(
+                `${server}/dhis-web-commons-security/login.action`,
+                {
+                    method: 'POST',
+                    credentials: 'include',
+                    body: `j_username=${username}&j_password=${password}`,
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        Accept: 'application/json',
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                }
+            )
+    } catch (e) {
+        // This will always happen because we don't have a real login endpoint
+    } finally {
+        window.location.reload()
+    }
+
 });
 
 export default accountActions;

--- a/src/app.router.js
+++ b/src/app.router.js
@@ -17,6 +17,7 @@ import TwoFactor from './account/twoFactor/TwoFactor';
 import UserSettings from './settings/UserSettings.component';
 import ViewProfile from './viewProfile/ViewProfile.component';
 import AboutPage from './aboutPage/AboutPage.component';
+import PasswordChangeSuccessDialog from './account/PasswordChangeSuccessDialog';
 
 function WrAppadApp(props) {
     return (
@@ -48,6 +49,7 @@ class AppRouter extends Component {
                             <Route path="profile" component={Profile} />
                             <Route path="account" component={Account} />
                             <Route path="twoFactor" component={TwoFactor} />
+                            <Route path="passwordChanged" component={PasswordChangeSuccessDialog} />
                             <Route path="viewProfile" component={ViewProfile} />
                             <Route path="aboutPage" component={AboutPage} />
                             <Redirect from="/" to="/viewProfile" />

--- a/src/layout/Snackbar.component.js
+++ b/src/layout/Snackbar.component.js
@@ -10,11 +10,14 @@ const messageStatus = {
     success: { backgroundColor: '#9CCC65' },
 };
 
+const DEFAULT_AUTOHIDE_DURATION = 1250
+
 class SnackWrapper extends Component {
     state = {
         snackbarMessage: '',
         showSnackbar: false,
         messageStatus: messageStatus['neutral'],
+        autoHideDuration: DEFAULT_AUTOHIDE_DURATION
     };
     
     componentDidMount() {
@@ -23,10 +26,13 @@ class SnackWrapper extends Component {
         this.subscriptions.push(appActions.showSnackbarMessage.subscribe((params) => {
             const message = params.data.message;
             const status = params.data.status ? params.data.status : 'neutral';
+            const autoHideDuration = params.data.permanent ? undefined : DEFAULT_AUTOHIDE_DURATION
+
             this.setState({ 
                 snackbarMessage: message, 
                 showSnackbar: !!message,
                 messageStatus: messageStatus[status],
+                autoHideDuration,
             });
         }));
     }
@@ -45,7 +51,7 @@ class SnackWrapper extends Component {
         return (
             <Snackbar
                 message={this.state.snackbarMessage}
-                autoHideDuration={1250}
+                autoHideDuration={this.state.autoHideDuration}
                 bodyStyle={this.state.messageStatus}
                 open={this.state.showSnackbar}
                 onRequestClose={this.closeSnackbar}


### PR DESCRIPTION
The reason for this PR is that there's been a change in the backend and now sessions are invalidated after a password change. The user will need to log in again in order to continue using the application.

This PR is in draft because I essentially have two different solutions, but I'm pretty unhappy about both of them...
- The most simple solution, as implemented in https://github.com/dhis2/user-profile-app/commit/ec779c5288fde788cf20c91f997d421afe10d135 just refreshes the window. My assumption was that the user would get redirected to the login screen, and then (after a successful login)  get redirected to the original route in the user-profile app. But I have found that the redirect part is not working properly (FYI, you can only test this properly after deploying the app locally). It is redirecting to the correct hash but the incorrect path (it just uses the dashboard-app). Perhaps this is because the user-profile-app is not part of the registered apps, so redirects aren't working anyway?
- I also tried an alternative approach, which I implemented here https://github.com/dhis2/user-profile-app/commit/ef78174a22678885631ed6a85f469a2cb4a7b49f. This time I tried to login via a POST and then refresh the window once done ([identical to this](https://github.com/dhis2/app-platform/blob/master/shell/adapter/src/AuthBoundary/LoginModal.js#L20-L44). But I also couldn't this to work. Not sure why yet.

So it would be great if you guys have any ideas about taking this issue further. I am a little bit stumped...

Or perhaps @amcgee could have a look, as you expressed some interest in this problem over Slack 💪 