### PR TITLE
fix: update endpoint used to change avatar photo

### DIFF
--- a/src/profile/profile.actions.js
+++ b/src/profile/profile.actions.js
@@ -73,8 +73,7 @@ function getProfileUpdatePromise({ key, value, payload, userId, d2 }) {
     if (key === 'avatar') {
         if (value) {
             // Set avatar
-            // Post avatar directly to the `/user/<ID>` endpoint, because d2 update calls to `/me` cause issues
-            return api.patch(`/users/${userId}`, { avatar: value.id })
+            return api.update('me', { avatar: { id: value.id } })
         } else {
             // Clear avatar
             return removeAvatar(userId, api)


### PR DESCRIPTION
fixes [DHIS2-15148 ](https://dhis2.atlassian.net/browse/)

Changes the endpoint used to update the avatar from `PATCH /users` to `PUT /me` to address some permissions issues with the PATCH endpoint as described [here](https://dhis2.atlassian.net/browse/DHIS2-9761) and related to https://dhis2.atlassian.net/browse/DHIS2-14223


| Before | After |
| --- | --- |
| <img width="822" alt="image" src="https://user-images.githubusercontent.com/1014725/233362152-94c93eca-fc94-4704-8c99-efda1ad0707d.png"> | <img width="845" alt="image" src="https://user-images.githubusercontent.com/1014725/233361967-b934dc9d-1083-448b-b00b-fafbd7fad699.png"> |

