### PR TITLE
feat: only show pats that you created

### DIFF
--- a/src/personalAccessTokens/PersonalAccessTokens.component.js
+++ b/src/personalAccessTokens/PersonalAccessTokens.component.js
@@ -2,6 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import { Card, Button } from '@dhis2/ui'
 import React, { useState } from 'react'
 import i18n from '../locales/index.js'
+import userProfileStore from '../profile/profile.store.js'
 import GenerateTokenModal from './generateTokenModal/GenerateTokenModal.component.js'
 import styles from './PersonalAccessTokens.module.css'
 import TokensList from './TokensList.component.js'
@@ -10,16 +11,20 @@ import { useModal } from './use-modal.js'
 const query = {
     tokens: {
         resource: 'apiToken',
-        params: {
+        params: (({userId}) => ({
             fields: ['id', 'created', 'expire', 'attributes'],
             paging: false,
-        },
-    },
+            filter: `createdBy.id:eq:${userId}`
+        })),
+    }
 }
 
 const PersonalAccessTokens = () => {
+
+    const userId = userProfileStore.state.id
     const [tokenKeys, setTokenKeys] = useState(new Map())
-    const { loading, error, data, refetch } = useDataQuery(query)
+    const {loading, error, data, refetch} =
+        useDataQuery(query, {variables: {userId}})
     const generateTokenModal = useModal()
 
     const tokens = data?.tokens.apiToken

--- a/src/personalAccessTokens/PersonalAccessTokens.component.js
+++ b/src/personalAccessTokens/PersonalAccessTokens.component.js
@@ -11,20 +11,20 @@ import { useModal } from './use-modal.js'
 const query = {
     tokens: {
         resource: 'apiToken',
-        params: (({userId}) => ({
+        params: ({ userId }) => ({
             fields: ['id', 'created', 'expire', 'attributes'],
             paging: false,
-            filter: `createdBy.id:eq:${userId}`
-        })),
-    }
+            filter: `createdBy.id:eq:${userId}`,
+        }),
+    },
 }
 
 const PersonalAccessTokens = () => {
-
     const userId = userProfileStore.state.id
     const [tokenKeys, setTokenKeys] = useState(new Map())
-    const {loading, error, data, refetch} =
-        useDataQuery(query, {variables: {userId}})
+    const { loading, error, data, refetch } = useDataQuery(query, {
+        variables: { userId },
+    })
     const generateTokenModal = useModal()
 
     const tokens = data?.tokens.apiToken


### PR DESCRIPTION
# Summary
Adds an API query filter on "createdBy" the current user's ID to show only personal access tokens created by the current user.
Without this filter, a user with "ALL" access would see everyone's tokens (not the actual token key, since that is hashed and not shown/ignored in the JSON response)

JIRA: [DHIS2-15470](https://dhis2.atlassian.net/browse/DHIS2-15470) 

[DHIS2-15470]: https://dhis2.atlassian.net/browse/DHIS2-15470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ