### PR TITLE
chore: bump to v100.0.0 for continuous release

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -12,6 +12,7 @@ env:
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
 
+
 jobs:
     install:
         runs-on: ubuntu-latest


### PR DESCRIPTION
BREAKING CHANGE: bump to v100.0.0 for continuous release