### PR TITLE
feat: show email update warning with email 2fa [DHIS2-18832]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-13T12:24:07.871Z\n"
-"PO-Revision-Date: 2025-02-13T12:24:07.871Z\n"
+"POT-Creation-Date: 2025-02-17T12:18:36.863Z\n"
+"PO-Revision-Date: 2025-02-17T12:18:36.864Z\n"
 
 msgid "Never"
 msgstr "Never"
@@ -318,6 +318,27 @@ msgstr "Email is invalid"
 msgid "Emails must match"
 msgstr "Emails must match"
 
+msgid "Email update not allowed"
+msgstr "Email update not allowed"
+
+msgid "Your email is currently used for two factor authentication"
+msgstr "Your email is currently used for two factor authentication"
+
+msgid ""
+"To update your email, you must first disable two factor authentication by "
+"email. After this has been disabled, you can change your email and then set "
+"up two factor authentication again."
+msgstr ""
+"To update your email, you must first disable two factor authentication by "
+"email. After this has been disabled, you can change your email and then set "
+"up two factor authentication again."
+
+msgid "Disable two factor authentication here"
+msgstr "Disable two factor authentication here"
+
+msgid "Cancel"
+msgstr "Cancel"
+
 msgid "Remove email"
 msgstr "Remove email"
 
@@ -326,9 +347,6 @@ msgstr "Your email is currently verified"
 
 msgid "Are you sure you want to remove your email?"
 msgstr "Are you sure you want to remove your email?"
-
-msgid "Cancel"
-msgstr "Cancel"
 
 msgid "Change email"
 msgstr "Change email"
@@ -422,6 +440,9 @@ msgstr "Email verification link sent successfully!"
 
 msgid "Failed to send email verification link."
 msgstr "Failed to send email verification link."
+
+msgid "Email already verified"
+msgstr "Email already verified"
 
 msgid "Verify email"
 msgstr "Verify email"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-17T12:18:36.863Z\n"
-"PO-Revision-Date: 2025-02-17T12:18:36.864Z\n"
+"POT-Creation-Date: 2025-02-18T16:33:28.306Z\n"
+"PO-Revision-Date: 2025-02-18T16:33:28.307Z\n"
 
 msgid "Never"
 msgstr "Never"
@@ -192,17 +192,44 @@ msgstr "Login"
 msgid "Failed to update password"
 msgstr "Failed to update password"
 
+msgid "Authenticator app"
+msgstr "Authenticator app"
+
+msgid "Email"
+msgstr "Email"
+
+msgid "Could not enable two factor authentication"
+msgstr "Could not enable two factor authentication"
+
+msgid "Two factor authentication was enabled successfully"
+msgstr "Two factor authentication was enabled successfully"
+
+msgid "Could not disable two factor authentication"
+msgstr "Could not disable two factor authentication"
+
+msgid "Two factor authentication was disabled successfully"
+msgstr "Two factor authentication was disabled successfully"
+
 msgid "Two-factor Authentication"
 msgstr "Two-factor Authentication"
+
+msgid ""
+"Two-factor authentication protects your account with an extra layer of "
+"security. With two-factor authentication turned on, you will need to enter "
+"an authentication code every time you log in."
+msgstr ""
+"Two-factor authentication protects your account with an extra layer of "
+"security. With two-factor authentication turned on, you will need to enter "
+"an authentication code every time you log in."
 
 msgid "Turn off two-factor authentication"
 msgstr "Turn off two-factor authentication"
 
-msgid "Open your authenticator app."
-msgstr "Open your authenticator app."
+msgid "Turn on two-factor authentication"
+msgstr "Turn on two-factor authentication"
 
-msgid "Now, enter the authentication code below and click the \"Turn off\" button."
-msgstr "Now, enter the authentication code below and click the \"Turn off\" button."
+msgid "Two factor authentication type"
+msgstr "Two factor authentication type"
 
 msgid "Remove two-factor account"
 msgstr "Remove two-factor account"
@@ -216,28 +243,27 @@ msgstr ""
 "the account from your authenticator app now to prevent any future issues "
 "re-enabling two-factor authentication."
 
-msgid "Play store"
-msgstr "Play store"
+msgid "Send authentication code to your verified email address: {{emailAddress}}"
+msgstr "Send authentication code to your verified email address: {{emailAddress}}"
 
-msgid "App store"
-msgstr "App store"
-
-msgid "Turn on two-factor authentication"
-msgstr "Turn on two-factor authentication"
+msgid "Authentication code sent"
+msgstr "Authentication code sent"
 
 msgid ""
-"Make sure you have an authenticator app installed on your device. We "
-"recommend Google Authenticator"
+"If you didn't receive the code, check your spam/junk folder. Have you "
+"waited a few minutes and still not received the code?"
 msgstr ""
-"Make sure you have an authenticator app installed on your device. We "
-"recommend Google Authenticator"
+"If you didn't receive the code, check your spam/junk folder. Have you "
+"waited a few minutes and still not received the code?"
 
-msgid ""
-"Now, enter the code from your authenticator app below and click the \"Turn "
-"on\" button."
-msgstr ""
-"Now, enter the code from your authenticator app below and click the \"Turn "
-"on\" button."
+msgid "Send a new code"
+msgstr "Send a new code"
+
+msgid "Send authentication code"
+msgstr "Send authentication code"
+
+msgid "Enter the 6 digit authentication code in the email."
+msgstr "Enter the 6 digit authentication code in the email."
 
 msgid "Already set up two-factor authentication before?"
 msgstr "Already set up two-factor authentication before?"
@@ -252,6 +278,18 @@ msgstr ""
 "again."
 
 msgid ""
+"Your email is not verified. You must verify or your email to enable or "
+"disable two-factor authentication via email. If you have recently verified "
+"your email, you may need to refresh this page."
+msgstr ""
+"Your email is not verified. You must verify or your email to enable or "
+"disable two-factor authentication via email. If you have recently verified "
+"your email, you may need to refresh this page."
+
+msgid "Verify your email here."
+msgstr "Verify your email here."
+
+msgid ""
 "Two-factor authentication protects your account with an extra layer of "
 "security. With two-factor authentication turned on, you will need to enter "
 "an authentication code from your device every time you log in."
@@ -259,6 +297,32 @@ msgstr ""
 "Two-factor authentication protects your account with an extra layer of "
 "security. With two-factor authentication turned on, you will need to enter "
 "an authentication code from your device every time you log in."
+
+msgid "Open your authenticator app."
+msgstr "Open your authenticator app."
+
+msgid "Now, enter the authentication code below and click the \"Turn off\" button."
+msgstr "Now, enter the authentication code below and click the \"Turn off\" button."
+
+msgid "Play store"
+msgstr "Play store"
+
+msgid "App store"
+msgstr "App store"
+
+msgid ""
+"Make sure you have an authenticator app installed on your device. We "
+"recommend Google Authenticator"
+msgstr ""
+"Make sure you have an authenticator app installed on your device. We "
+"recommend Google Authenticator"
+
+msgid ""
+"Now, enter the code from your authenticator app below and click the \"Turn "
+"on\" button."
+msgstr ""
+"Now, enter the code from your authenticator app below and click the \"Turn "
+"on\" button."
 
 msgid "Two-factor authentication is on."
 msgstr "Two-factor authentication is on."
@@ -276,20 +340,11 @@ msgstr ""
 "This code does not look right. Enter the six digit code from your "
 "authentication app."
 
-msgid "Six digit authentication code"
-msgstr "Six digit authentication code"
+msgid "6 digit code"
+msgstr "6 digit code"
 
 msgid "Could not enable 2 Factor Authentication"
 msgstr "Could not enable 2 Factor Authentication"
-
-msgid "Two factor authentication was enabled successfully"
-msgstr "Two factor authentication was enabled successfully"
-
-msgid "Could not disable two factor authentication"
-msgstr "Could not disable two factor authentication"
-
-msgid "Two factor authentication was disabled successfully"
-msgstr "Two factor authentication was disabled successfully"
 
 msgid "Please choose a profile avatar less than {{- maxSize}}MB in size."
 msgstr "Please choose a profile avatar less than {{- maxSize}}MB in size."
@@ -368,9 +423,6 @@ msgstr "Confirm new email"
 
 msgid "Save"
 msgstr "Save"
-
-msgid "Email"
-msgstr "Email"
 
 msgid "There is no email to remove"
 msgstr "There is no email to remove"

--- a/src/account/twoFactor/TwoFactorEmailCodeButton.js
+++ b/src/account/twoFactor/TwoFactorEmailCodeButton.js
@@ -13,6 +13,7 @@ const TwoFactorEmailCodeButton = ({ onClick, error, loading, success }) => {
                 'Send authentication code to your verified email address: {{emailAddress}}',
                 {
                     emailAddress: emailAddress,
+                    nsSeparator: '-:-',
                 }
             )}
             {success ? (

--- a/src/account/twoFactor/TwoFactorInstructions.js
+++ b/src/account/twoFactor/TwoFactorInstructions.js
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import { NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Link } from 'react-router'
 import styles from './TwoFactor.module.css'
 import TwoFactorEmailDisableInstructions from './TwoFactorEmailDisableInstructions.js'
 import TwoFactorEmailEnableInstructions from './TwoFactorEmailEnableInstructions.js'
@@ -21,7 +22,7 @@ const TwoFactorInstructions = ({
                     'Your email is not verified. You must verify or your email to enable or disable two-factor authentication via email. If you have recently verified your email, you may need to refresh this page.'
                 )}
                 <br />
-                <a href="#/profile">{i18n.t('Verify your email here.')}</a>
+                <Link to="/profile">{i18n.t('Verify your email here.')}</Link>
             </NoticeBox>
         )
     }

--- a/src/layout/EmailField.component.js
+++ b/src/layout/EmailField.component.js
@@ -13,6 +13,7 @@ import {
 import TextField from 'd2-ui/lib/form-fields/TextField'
 import PropTypes from 'prop-types'
 import React, { useMemo, useState } from 'react'
+import { Link } from 'react-router'
 import styles from './EmailField.component.module.css'
 import TooltipWrapper from './TooltipWrapper.js'
 import { VerifyEmail } from './VerifyEmail.component.js'
@@ -25,6 +26,57 @@ const getSaveDisabledContent = ({ newEmail, emailValidationMessage }) => {
         return i18n.t('Email is invalid')
     }
     return i18n.t('Emails must match')
+}
+
+const TwoFAWarningModal = ({
+    twoFAWarningModalOpen,
+    setTwoFAWarningModalOpen,
+}) => (
+    <Modal
+        hide={!twoFAWarningModalOpen}
+        onClose={() => setTwoFAWarningModalOpen(false)}
+    >
+        <ModalTitle>{i18n.t('Email update not allowed')}</ModalTitle>
+
+        <ModalContent>
+            <NoticeBox
+                className={styles.emailModalItem}
+                title={i18n.t(
+                    'Your email is currently used for two factor authentication'
+                )}
+                warning
+            >
+                <div className={styles.emailModalText}>
+                    <div>
+                        {i18n.t(
+                            'To update your email, you must first disable two factor authentication by email. After this has been disabled, you can change your email and then set up two factor authentication again.'
+                        )}
+                    </div>
+                    <Link to="/twoFactor">
+                        <div>
+                            {i18n.t('Disable two factor authentication here')}
+                        </div>
+                    </Link>
+                </div>
+            </NoticeBox>
+        </ModalContent>
+
+        <ModalActions>
+            <ButtonStrip end>
+                <Button
+                    onClick={() => setTwoFAWarningModalOpen(false)}
+                    secondary
+                >
+                    {i18n.t('Cancel')}
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
+    </Modal>
+)
+
+TwoFAWarningModal.propTypes = {
+    setTwoFAWarningModalOpen: PropTypes.func,
+    twoFAWarningModalOpen: PropTypes.bool,
 }
 
 const RemoveModal = ({
@@ -192,9 +244,15 @@ EmailModal.propTypes = {
     onUpdate: PropTypes.func,
 }
 
-export function EmailField({ userEmail, userEmailVerified, onUpdate }) {
+export function EmailField({
+    userEmail,
+    userEmailVerified,
+    twoFaByEmailInUse,
+    onUpdate,
+}) {
     const [emailModalOpen, setEmailModalOpen] = useState()
     const [removeModalOpen, setRemoveModalOpen] = useState()
+    const [twoFAWarningModalOpen, setTwoFAWarningModalOpen] = useState()
 
     return (
         <div className={styles.emailModalContainer}>
@@ -206,7 +264,16 @@ export function EmailField({ userEmail, userEmailVerified, onUpdate }) {
             />
             <div className={styles.buttonContainer}>
                 <VerifyEmail userEmail={userEmail} />
-                <Button secondary onClick={() => setEmailModalOpen(true)}>
+                <Button
+                    secondary
+                    onClick={() => {
+                        if (twoFaByEmailInUse) {
+                            setTwoFAWarningModalOpen(true)
+                        } else {
+                            setEmailModalOpen(true)
+                        }
+                    }}
+                >
                     {i18n.t('Change email')}
                 </Button>
                 <TooltipWrapper
@@ -215,7 +282,13 @@ export function EmailField({ userEmail, userEmailVerified, onUpdate }) {
                 >
                     <Button
                         destructive
-                        onClick={() => setRemoveModalOpen(true)}
+                        onClick={() => {
+                            if (twoFaByEmailInUse) {
+                                setTwoFAWarningModalOpen(true)
+                            } else {
+                                setRemoveModalOpen(true)
+                            }
+                        }}
                         disabled={!userEmail || userEmail?.trim() === ''}
                     >
                         {i18n.t('Remove email')}
@@ -237,11 +310,18 @@ export function EmailField({ userEmail, userEmailVerified, onUpdate }) {
                 userEmailVerified={userEmailVerified}
                 onUpdate={onUpdate}
             />
+            <TwoFAWarningModal
+                twoFAWarningModalOpen={twoFAWarningModalOpen}
+                setTwoFAWarningModalOpen={setTwoFAWarningModalOpen}
+                userEmailVerified={userEmailVerified}
+                onUpdate={onUpdate}
+            />
         </div>
     )
 }
 
 EmailField.propTypes = {
+    twoFaByEmailInUse: PropTypes.bool,
     userEmail: PropTypes.string,
     userEmailVerified: PropTypes.bool,
     onUpdate: PropTypes.func,

--- a/src/layout/EmailField.component.js
+++ b/src/layout/EmailField.component.js
@@ -318,8 +318,6 @@ export function EmailField({
             <TwoFAWarningModal
                 twoFAWarningModalOpen={twoFAWarningModalOpen}
                 setTwoFAWarningModalOpen={setTwoFAWarningModalOpen}
-                userEmailVerified={userEmailVerified}
-                onUpdate={onUpdate}
             />
         </div>
     )

--- a/src/layout/EmailField.component.module.css
+++ b/src/layout/EmailField.component.module.css
@@ -10,6 +10,10 @@
     margin-block-end: 16px;
 }
 
+.emailModalText div {
+    margin-block-end: 8px;
+}
+
 .buttonContainer {
     display: flex;
     gap: 8px;

--- a/src/layout/FormFields.component.js
+++ b/src/layout/FormFields.component.js
@@ -246,6 +246,8 @@ function createEmailField({ fieldBase, valueStore, onUpdate, d2 }) {
             },
             userEmail: valueStore.state['email'] || '',
             userEmailVerified: d2?.currentUser?.emailVerified,
+            twoFaByEmailInUse:
+                d2?.currentUser?.twoFactorType === 'EMAIL_ENABLED',
         },
     })
 }


### PR DESCRIPTION
See ticket https://dhis2.atlassian.net/browse/DHIS2-18832

This changes the user email modification to provide a warning in the case that the user is using 2fa by email:

<img width="642" alt="image" src="https://github.com/user-attachments/assets/5fa54a92-ca47-4272-9a25-e00bb1fc7775" />

### Notes
This warning applies based on if you have 2fa enabled when the app opens. If you add 2fa by email then go to the User profile page, you will be allowed to update the email without this warning. This seems acceptable to me because the backend will in this case your attempt to reject the email. The frontend warning here is just trying to make the workflow slightly easier and I don't think it's likely that you will set up 2fa by email and then immediately try to change your email in the same session.

### Testing

No automated tests because this app does not have any.
[IN DRAFT until 2fa by email configuration PR is merged, in order to test]