### PR TITLE
fix(DHIS2-19863): introduce code field in api tokens 

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-03-18T18:29:13.632Z\n"
-"PO-Revision-Date: 2025-03-18T18:29:13.632Z\n"
+"POT-Creation-Date: 2025-07-22T12:12:24.931Z\n"
+"PO-Revision-Date: 2025-07-22T12:12:24.931Z\n"
 
 msgid "Never"
 msgstr "Never"
@@ -588,6 +588,12 @@ msgstr ""
 "be spoofed. This setting is intended to discourage unauthorised third-party "
 "developers from connecting to public access instances."
 
+msgid "Token name"
+msgstr "Token name"
+
+msgid "A unique name for this token."
+msgstr "A unique name for this token."
+
 msgid "Choose the context where this token will be used."
 msgstr "Choose the context where this token will be used."
 
@@ -633,6 +639,9 @@ msgstr "Expiration (required)"
 
 msgid "Custom expiration date (required)"
 msgstr "Custom expiration date (required)"
+
+msgid "Token name already exists"
+msgstr "Token name already exists"
 
 msgid ""
 "Personal access tokens should only be used in a browser context for public "
@@ -684,6 +693,9 @@ msgstr "Copied token to clipboard"
 
 msgid "Newly created token"
 msgstr "Newly created token"
+
+msgid "Token Name"
+msgstr "Token Name"
 
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
@@ -824,3 +836,11 @@ msgstr "PATCH"
 msgctxt "HTTP method"
 msgid "DELETE"
 msgstr "DELETE"
+
+msgctxt "Application title"
+msgid "__MANIFEST_APP_TITLE"
+msgstr "User Profile"
+
+msgctxt "Application description"
+msgid "__MANIFEST_APP_DESCRIPTION"
+msgstr "User Profile App for DHIS2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "format:js": "d2-style apply js",
         "format:text": "d2-style apply text",
         "format:staged": "yarn format:js --staged && yarn format:text --staged",
-        "format": "d2-style apply js && d2-style apply text"
+        "format": "d2-style apply js && d2-style apply text && d2-style apply text css"
     },
     "devDependencies": {
         "@dhis2/cli-app-scripts": "^12.5.1",

--- a/src/personalAccessTokens/PersonalAccessTokens.component.jsx
+++ b/src/personalAccessTokens/PersonalAccessTokens.component.jsx
@@ -1,5 +1,5 @@
 import { useDataQuery } from '@dhis2/app-runtime'
-import { Card, Button } from '@dhis2/ui'
+import { Button, Card } from '@dhis2/ui'
 import React, { useState } from 'react'
 import i18n from '../locales/index.js'
 import userProfileStore from '../profile/profile.store.js'
@@ -12,7 +12,7 @@ const query = {
     tokens: {
         resource: 'apiToken',
         params: ({ userId }) => ({
-            fields: ['id', 'created', 'expire', 'attributes'],
+            fields: ['id', 'code', 'created', 'expire', 'attributes'],
             paging: false,
             filter: `createdBy.id:eq:${userId}`,
         }),
@@ -28,9 +28,10 @@ const PersonalAccessTokens = () => {
     const generateTokenModal = useModal()
 
     const tokens = data?.tokens.apiToken
-        .map(({ id, created, expire, attributes }) => {
+        .map(({ id, created, expire, attributes, code }) => {
             return {
                 id,
+                code,
                 attributes,
                 createdAt: new Date(created),
                 expiresAt: new Date(expire),

--- a/src/personalAccessTokens/generateTokenModal/BrowserForm.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/BrowserForm.component.jsx
@@ -4,11 +4,15 @@ import React from 'react'
 import i18n from '../../locales/index.js'
 import AllowedMethodsFF from './AllowedMethodsFF.component.jsx'
 import AllowedReferrersFF from './AllowedReferrersFF.component.jsx'
+import CodeFF from './CodeFF.component.jsx'
 import ExpirationDateFF from './ExpirationDateFF.component.jsx'
 import styles from './Form.module.css'
 
 const BrowserForm = ({ values }) => (
     <>
+        <div className={styles.field}>
+            <CodeFF />
+        </div>
         <div className={styles.field}>
             <ExpirationDateFF values={values} />
         </div>

--- a/src/personalAccessTokens/generateTokenModal/CodeFF.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/CodeFF.component.jsx
@@ -1,0 +1,21 @@
+import { hasValue, InputFieldFF, ReactFinalForm } from '@dhis2/ui'
+import React from 'react'
+import i18n from '../../locales/index.js'
+import classes from './CodeFF.module.css'
+
+const CodeFF = () => {
+    return (
+        <div className={classes.container}>
+            <ReactFinalForm.Field
+                label={i18n.t('Token name')}
+                component={InputFieldFF}
+                validate={hasValue}
+                name="code"
+                helpText={i18n.t('A unique name for this token.')}
+                required
+            />
+        </div>
+    )
+}
+
+export default CodeFF

--- a/src/personalAccessTokens/generateTokenModal/CodeFF.module.css
+++ b/src/personalAccessTokens/generateTokenModal/CodeFF.module.css
@@ -1,0 +1,3 @@
+.container {
+    max-width: min(360px, 100%);
+}

--- a/src/personalAccessTokens/generateTokenModal/ServerForm.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/ServerForm.component.jsx
@@ -4,11 +4,15 @@ import React from 'react'
 import i18n from '../../locales/index.js'
 import AllowedIpsFF from './AllowedIpsFF.component.jsx'
 import AllowedMethodsFF from './AllowedMethodsFF.component.jsx'
+import CodeFF from './CodeFF.component.jsx'
 import ExpirationDateFF from './ExpirationDateFF.component.jsx'
 import styles from './Form.module.css'
 
 const ServerForm = ({ values }) => (
     <>
+        <div className={styles.field}>
+            <CodeFF />
+        </div>
         <div className={styles.field}>
             <ExpirationDateFF values={values} />
         </div>

--- a/src/personalAccessTokens/tokenCard/ExistingToken.component.jsx
+++ b/src/personalAccessTokens/tokenCard/ExistingToken.component.jsx
@@ -42,7 +42,7 @@ Item.propTypes = {
 }
 
 const ExistingToken = ({ token }) => {
-    const { attributes, createdAt, expiresAt } = token
+    const { attributes, createdAt, expiresAt, code } = token
     const allowedMethods = getAttribute(
         attributes,
         'MethodAllowedList',
@@ -57,6 +57,11 @@ const ExistingToken = ({ token }) => {
 
     return (
         <dl className={styles.items}>
+            {code && (
+                <Item title={i18n.t('Token name')} singleLine>
+                    {code ?? ''}
+                </Item>
+            )}
             <Item title={i18n.t('Expires')} singleLine>
                 <RelativeDateTime dateTime={expiresAt} />
             </Item>

--- a/src/personalAccessTokens/tokenCard/NewToken.component.jsx
+++ b/src/personalAccessTokens/tokenCard/NewToken.component.jsx
@@ -9,6 +9,7 @@ const NewToken = ({ token }) => {
     const copiedAlert = useAlert(i18n.t('Copied token to clipboard'), {
         success: true,
     })
+
     const handleCopy = () => {
         navigator.clipboard.writeText(token.key)
         copiedAlert.show()
@@ -17,6 +18,12 @@ const NewToken = ({ token }) => {
     return (
         <div>
             <h3 className={styles.header}>{i18n.t('Newly created token')}</h3>
+            {token.code && (
+                <div className={styles.item}>
+                    <dt className={styles.itemTitle}>{i18n.t('Token Name')}</dt>
+                    <dd className={styles.itemValue}>{token.code}</dd>
+                </div>
+            )}
             <div className={styles.token}>
                 {token.key}
                 <Button onClick={handleCopy} icon={<IconCopy16 />} small>

--- a/src/personalAccessTokens/tokenCard/NewToken.module.css
+++ b/src/personalAccessTokens/tokenCard/NewToken.module.css
@@ -5,6 +5,22 @@
     margin-bottom: var(--spacers-dp4);
 }
 
+.item {
+    display: grid;
+    gap: var(--spacers-dp8);
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    margin-bottom: var(--spacers-dp8);
+}
+
+.itemTitle {
+    font-weight: 500;
+}
+
+.itemValue {
+    margin: 0;
+}
+
 .token {
     display: flex;
     align-items: center;


### PR DESCRIPTION
implements: https://dhis2.atlassian.net/browse/DHIS2-19863

This implementation adds a code field to the PAT generation form and a code display in the token list card, allowing users to label their tokens according to their intended use.

Note: This implementation requires [This pull request](https://github.com/dhis2/dhis2-core/pull/21435)

Screenshots:

<img width="1223" height="656" alt="Screenshot 2025-07-18 at 12 25 57" src="https://github.com/user-attachments/assets/c928c0b6-169b-43a6-a756-dd83f5d5d4cb" />

<img width="1264" height="639" alt="Screenshot 2025-07-18 at 12 27 06" src="https://github.com/user-attachments/assets/018d6319-e876-4304-a0bc-8e944bc91bca" />

