### PR TITLE
feat: add HEAD method to token generation modal

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-07-22T12:12:24.931Z\n"
-"PO-Revision-Date: 2025-07-22T12:12:24.931Z\n"
+"POT-Creation-Date: 2025-08-07T19:11:36.629Z\n"
+"PO-Revision-Date: 2025-08-07T19:11:36.629Z\n"
 
 msgid "Never"
 msgstr "Never"
@@ -546,6 +546,9 @@ msgstr "Allowed HTTP methods"
 msgid "GET"
 msgstr "GET"
 
+msgid "HEAD"
+msgstr "HEAD"
+
 msgid "POST"
 msgstr "POST"
 
@@ -820,6 +823,10 @@ msgstr "View full profile"
 msgctxt "HTTP method"
 msgid "GET"
 msgstr "GET"
+
+msgctxt "HTTP method"
+msgid "HEAD"
+msgstr "HEAD"
 
 msgctxt "HTTP method"
 msgid "POST"

--- a/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
@@ -3,22 +3,23 @@ import React from 'react'
 import i18n from '../../locales/index.js'
 import styles from './AllowedMethodsFF.module.css'
 
+
 const AllowedMethodsFF = () => (
     <>
         <h3 className={styles.header}>{i18n.t('Allowed HTTP methods')}</h3>
-        <ReactFinalForm.Field
-            name="allowedMethodsGET"
-            label={i18n.t('GET', { context: 'HTTP method' })}
-            type="checkbox"
-            component={CheckboxFieldFF}
-            initialValue={true}
-        />
         <ReactFinalForm.Field
             name="allowedMethodsHEAD"
             label={i18n.t('HEAD', { context: 'HTTP method' })}
             type="checkbox"
             component={CheckboxFieldFF}
             initialValue={false}
+        />
+        <ReactFinalForm.Field
+            name="allowedMethodsGET"
+            label={i18n.t('GET', { context: 'HTTP method' })}
+            type="checkbox"
+            component={CheckboxFieldFF}
+            initialValue={true}
         />
         <ReactFinalForm.Field
             name="allowedMethodsPOST"

--- a/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
@@ -14,6 +14,13 @@ const AllowedMethodsFF = () => (
             initialValue={true}
         />
         <ReactFinalForm.Field
+            name="allowedMethodsHEAD"
+            label={i18n.t('HEAD', { context: 'HTTP method' })}
+            type="checkbox"
+            component={CheckboxFieldFF}
+            initialValue={false}
+        />
+        <ReactFinalForm.Field
             name="allowedMethodsPOST"
             label={i18n.t('POST', { context: 'HTTP method' })}
             type="checkbox"

--- a/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.jsx
@@ -3,7 +3,6 @@ import React from 'react'
 import i18n from '../../locales/index.js'
 import styles from './AllowedMethodsFF.module.css'
 
-
 const AllowedMethodsFF = () => (
     <>
         <h3 className={styles.header}>{i18n.t('Allowed HTTP methods')}</h3>

--- a/src/personalAccessTokens/generateTokenModal/GenerateTokenModal.component.jsx
+++ b/src/personalAccessTokens/generateTokenModal/GenerateTokenModal.component.jsx
@@ -58,6 +58,7 @@ const getAllowedIpsAttribute = ({ allowedIps }) => {
 
 const getAllowedMethodsAttribute = ({
     allowedMethodsGET,
+    allowedMethodsHEAD,
     allowedMethodsPOST,
     allowedMethodsPUT,
     allowedMethodsPATCH,
@@ -67,6 +68,7 @@ const getAllowedMethodsAttribute = ({
         type: 'MethodAllowedList',
         allowedMethods: [
             allowedMethodsGET && 'GET',
+            allowedMethodsHEAD && 'HEAD',
             allowedMethodsPOST && 'POST',
             allowedMethodsPUT && 'PUT',
             allowedMethodsPATCH && 'PATCH',


### PR DESCRIPTION
- Introduced a new checkbox for the HEAD HTTP method in the 
AllowedMethodsFF component.
- Updated the getAllowedMethodsAttribute function to include the 
HEAD method in the allowed methods list.