### PR TITLE
fix: remove head method from v40 [DHIS2-200080]

### DIFF
--- a/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.js
+++ b/src/personalAccessTokens/generateTokenModal/AllowedMethodsFF.component.js
@@ -7,13 +7,6 @@ const AllowedMethodsFF = () => (
     <>
         <h3 className={styles.header}>{i18n.t('Allowed HTTP methods')}</h3>
         <ReactFinalForm.Field
-            name="allowedMethodsHEAD"
-            label={i18n.t('HEAD', { context: 'HTTP method' })}
-            type="checkbox"
-            component={CheckboxFieldFF}
-            initialValue={false}
-        />
-        <ReactFinalForm.Field
             name="allowedMethodsGET"
             label={i18n.t('GET', { context: 'HTTP method' })}
             type="checkbox"

--- a/src/personalAccessTokens/generateTokenModal/GenerateTokenModal.component.js
+++ b/src/personalAccessTokens/generateTokenModal/GenerateTokenModal.component.js
@@ -58,7 +58,6 @@ const getAllowedIpsAttribute = ({ allowedIps }) => {
 
 const getAllowedMethodsAttribute = ({
     allowedMethodsGET,
-    allowedMethodsHEAD,
     allowedMethodsPOST,
     allowedMethodsPUT,
     allowedMethodsPATCH,
@@ -68,7 +67,6 @@ const getAllowedMethodsAttribute = ({
         type: 'MethodAllowedList',
         allowedMethods: [
             allowedMethodsGET && 'GET',
-            allowedMethodsHEAD && 'HEAD',
             allowedMethodsPOST && 'POST',
             allowedMethodsPUT && 'PUT',
             allowedMethodsPATCH && 'PATCH',


### PR DESCRIPTION
see https://dhis2.atlassian.net/browse/DHIS2-20080

This PR removes HEAD method for PAT for v40.